### PR TITLE
Fix header to be older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>RAG Chatbot</title>
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body>
@@ -17,10 +17,6 @@
             <span class="moon-icon">🌙</span>
         </button>
         
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
 
         <div class="main-content">
             <!-- Left Sidebar -->

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -138,26 +138,6 @@ body {
     transform: rotate(-180deg) scale(0.5);
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -762,13 +742,6 @@ details[open] .suggested-header::before {
         order: 1;
     }
     
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
     
     .chat-messages {
         padding: 1rem;


### PR DESCRIPTION
Removes the Course Materials Assistant header, subheader, and related elements while preserving the theme toggle functionality.

## Changes
- Removed "Course Materials Assistant" header text
- Removed subtitle "Ask questions about courses, instructors, and content"
- Removed entire header section from HTML
- Cleaned up unused CSS styles
- Updated page title to "RAG Chatbot"
- Preserved theme toggle functionality

Fixes #2

Generated with [Claude Code](https://claude.ai/code)